### PR TITLE
Update vendor auth details and contribution notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ To propose a new vendor or project, please:
   lowercase, hyphenated identifier for your project
 - Validate it using the schema in `schema/`
 - Open a pull request
+- Projects must re-apply for certification when a new **major version** is released.
+- Only English language submissions are accepted.
 
 After adding a vendor file you can run `python generate-summary.py` to refresh
 `public/summary.json`.

--- a/public/summary.json
+++ b/public/summary.json
@@ -6,4 +6,3 @@
     "saml_support": false
   }
 ]
-

--- a/vendors/acme.json
+++ b/vendors/acme.json
@@ -15,5 +15,14 @@
   "oidc_support": true,
   "saml_support": false,
   "public_docs_url": "https://acme.example.com/docs",
-  "license_type": "Apache-2.0"
+  "license_type": "Apache-2.0",
+  "auth": {
+    "oidc": true,
+    "saml": false,
+    "ldap": true
+  },
+  "documentation": "https://example.com/docs/sso",
+  "version": "2.1.0",
+  "status": "certified",
+  "certified_at": "2025-06-18"
 }


### PR DESCRIPTION
## Summary
- add authentication section and certification fields to `acme.json`
- document recertification policy and language requirements in README
- regenerate summary

## Testing
- `python generate-summary.py`
- `check-jsonschema vendors/acme.json --schemafile schema/vendor-entry-schema.json`


------
https://chatgpt.com/codex/tasks/task_e_6856ea0bb0b48323a5997e25c46d48d2